### PR TITLE
Make the `Value` indexable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+- Add `Index` impls for `msgpack_value::Value`
+
 ### Fixed
 
 ### Removed

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -457,13 +457,13 @@ impl Index<&str> for Value {
     }
 }
 
-impl Index<i32> for Value {
+impl Index<usize> for Value {
     type Output = Value;
-    fn index(&self, index: i32) -> &Self::Output {
+    fn index(&self, index: usize) -> &Self::Output {
         let converted = self
             .as_array()
-            .expect("This doesn't look like an array, which is indexed by `i32`.");
-        let found_value = converted.get(index as usize);
+            .expect("This doesn't look like an array, which is indexed by `usize`.");
+        let found_value = converted.get(index);
         found_value.expect("There's no such index in this array")
     }
 }

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -489,7 +489,7 @@ impl Index for usize {
 
 impl<T> core::ops::Index<T> for Value
 where
-    T: Index
+    T: Index,
 {
     type Output = Value;
     fn index(&self, index: T) -> &Self::Output {
@@ -503,7 +503,7 @@ fn test_index() {
     let k = &v["foo"];
     assert_eq!(k.as_str().unwrap().as_bytes(), "bar".as_bytes());
 
-    let v = msgpack!([ "foo", "bar", "baz" ]);
+    let v = msgpack!(["foo", "bar", "baz"]);
     let k = &v[1];
     assert_eq!(k.as_str().unwrap().as_bytes(), "bar".as_bytes());
 }

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -277,6 +277,10 @@ impl Str {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 /// Byte array type.
@@ -288,6 +292,10 @@ pub struct Bin(pub Vec<u8>);
 impl Bin {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -487,6 +495,35 @@ where
     fn index(&self, index: T) -> &Self::Output {
         index.index(self)
     }
+}
+
+#[test]
+fn test_index() {
+    let v = msgpack!({ 0: 1, "foo" : "bar", "foo" : "baz" });
+    let k = &v["foo"];
+    assert_eq!(k.as_str().unwrap().as_bytes(), "bar".as_bytes());
+
+    let v = msgpack!([ "foo", "bar", "baz" ]);
+    let k = &v[1];
+    assert_eq!(k.as_str().unwrap().as_bytes(), "bar".as_bytes());
+}
+
+#[test]
+#[should_panic]
+fn test_index_panic_array_index_by_str() {
+    let _ = msgpack!([])["foo"];
+}
+
+#[test]
+#[should_panic]
+fn test_index_panic_array_out_of_range() {
+    let _ = msgpack!([])[0];
+}
+
+#[test]
+#[should_panic]
+fn test_index_panic_map_key_not_found() {
+    let _ = msgpack!({"foo":"bar"})["baz"];
 }
 
 /// Error type returned by `TryFrom<Value>` implementations.

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -2,6 +2,7 @@
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
+use std::ops::Index;
 use thiserror::Error;
 
 /// Integer ranging from `-(2^63)` to `(2^64)-1`.
@@ -435,6 +436,35 @@ impl From<Vec<Value>> for Value {
 impl From<Vec<(Value, Value)>> for Value {
     fn from(v: Vec<(Value, Value)>) -> Self {
         Self::Map(v)
+    }
+}
+
+impl Index<&str> for Value {
+    type Output = Value;
+    fn index(&self, index: &str) -> &Self::Output {
+        let converted = self
+            .as_map()
+            .expect("This doesn't look like a map, which is indexed by `&str`.");
+        let search_key = Value::from(index);
+        let mut found_value: Option<&Value> = None;
+        for (key, value) in converted {
+            if key == &search_key {
+                found_value = Some(value);
+                break;
+            }
+        }
+        found_value.expect("There's no such key in this map")
+    }
+}
+
+impl Index<i32> for Value {
+    type Output = Value;
+    fn index(&self, index: i32) -> &Self::Output {
+        let converted = self
+            .as_array()
+            .expect("This doesn't look like an array, which is indexed by `i32`.");
+        let found_value = converted.get(index as usize);
+        found_value.expect("There's no such index in this array")
     }
 }
 

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -450,28 +450,26 @@ impl<T: Index> Index for &T {
 
 impl Index for str {
     fn index<'a>(&self, v: &'a Value) -> &'a Value {
-        let converted = v
+        let map = v
             .as_map()
-            .expect("This doesn't look like a map, which is indexed by `&str`.");
-        let search_key = Value::from(self);
-        let mut found_value: Option<&Value> = None;
-        for (key, value) in converted {
-            if key == &search_key {
-                found_value = Some(value);
-                break;
+            .expect("this type of object is not indexable by str");
+        for (key, value) in map {
+            if let Some(Str(key)) = key.as_str() {
+                if key == self.as_bytes() {
+                    return value;
+                }
             }
         }
-        found_value.expect("There's no such key in this map")
+        panic!("key not found in object");
     }
 }
 
 impl Index for usize {
     fn index<'a>(&self, v: &'a Value) -> &'a Value {
-        let converted = v
+        let array = v
             .as_array()
-            .expect("This doesn't look like an array, which is indexed by `usize`.");
-        let found_value = converted.get(*self);
-        found_value.expect("There's no such index in this array")
+            .expect("this type of object is not indexable by usize");
+        &array[*self]
     }
 }
 

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -442,7 +442,7 @@ pub trait Index {
     fn index<'a>(&self, v: &'a Value) -> &'a Value;
 }
 
-impl<T: Index> Index for &T {
+impl<T: Index + ?Sized> Index for &T {
     fn index<'a>(&self, v: &'a Value) -> &'a Value {
         (*self).index(v)
     }

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -464,6 +464,12 @@ impl Index for str {
     }
 }
 
+impl Index for String {
+    fn index<'a>(&self, v: &'a Value) -> &'a Value {
+        self.as_str().index(v)
+    }
+}
+
 impl Index for usize {
     fn index<'a>(&self, v: &'a Value) -> &'a Value {
         let array = v


### PR DESCRIPTION
This PR does just what the title says

With this PR, operations like below are made possible:
```rust
let value:Value = deserialize(bytes).unwrap();
let inner:Value = value["someItem"]["breads"][3]; 
```