### PR TITLE
Support for more field level Serialization/Deserialization attributes

### DIFF
--- a/msgpack-schema-impl/src/lib.rs
+++ b/msgpack-schema-impl/src/lib.rs
@@ -6,7 +6,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// The `schema` attribute is experimental.
-#[proc_macro_derive(Serialize, attributes(schema, tag, optional, untagged, flatten))]
+#[proc_macro_derive(Serialize, attributes(schema, tag, optional, untagged, flatten, skip))]
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     serialize::derive(&input)
@@ -15,7 +15,10 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
 }
 
 /// The `schema` attribute is experimental.
-#[proc_macro_derive(Deserialize, attributes(schema, tag, optional, untagged, flatten))]
+#[proc_macro_derive(
+    Deserialize,
+    attributes(schema, tag, optional, untagged, flatten, skip, default)
+)]
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     deserialize::derive(&input)

--- a/msgpack-value/src/lib.rs
+++ b/msgpack-value/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(non_local_definitions)]
 //! The MessagePack Data Model
 //!
 //! See also the [specification](https://github.com/msgpack/msgpack/blob/master/spec.md).
@@ -237,7 +238,7 @@ impl Arbitrary for Int {
                 if high < 0 {
                     Int::from(high)
                 } else {
-                    Int::from((high as u64) << 1 | (low as u64))
+                    Int::from(((high as u64) << 1) | (low as u64))
                 }
             })
             .boxed()
@@ -264,8 +265,8 @@ impl Arbitrary for Int {
 /// it is recommended to use _string type_ instead of binary type for its encoding scheme for the following reasons.
 ///
 /// - It just saves some memory. If your byte array is less than 32 byte length, using string type instead of byte array saves one byte per object.
-/// - The disiction only matters when _not_ using a data schema. Because this crate offers a statically-typed data schema, and we know how to decode data into a Rust object at compile time,
-/// distinction of these types in the input binary data is almost useless,
+/// - The distinction only matters when _not_ using a data schema. Because this crate offers a statically-typed data schema, and we know how to decode data into a Rust object at compile time,
+///     distinction of these types in the input binary data is almost useless,
 ///
 /// Although we strongly recommend you to use string types rather than binary types, this crate does _not_ force you to do so.
 /// The functions and trait implementations provided by this crate are all taking a neutral stand.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,51 @@
+use msgpack_value::TryFromIntError;
+use thiserror::Error;
+
+/// This error type represents type mismatch errors during deserialization.
+#[derive(Debug, Error)]
+#[error("validation failed: {0}")]
+pub struct ValidationError(pub &'static str);
+
+/// This error type represents all possible errors during deserialization.
+#[derive(Debug, Error)]
+pub enum DeserializeError {
+    #[error(transparent)]
+    InvalidInput(#[from] InvalidInputError),
+    #[error(transparent)]
+    Validation(#[from] ValidationError),
+}
+
+/// This error type represents blob-to-MessegePack transcode errors.
+///
+/// This error type is raised during deserialization either
+/// 1. when (first bytes of) given binary data is not a message pack object, or
+/// 2. when it unexpectedly reaches the end of input.
+#[derive(Debug, Error)]
+#[error("invalid input: {0}")]
+pub struct InvalidInputError(pub &'static str);
+
+/// This error type represents errors during serialization.
+// #[derive(Debug, Error)]
+// #[error("failed to serialize: {0}")]
+// pub struct SerializeError(#[from] pub std::io::Error);
+#[derive(Debug, Error)]
+pub enum SerializeError {
+    #[error(transparent)]
+    InvalidInput(#[from] InvalidInputError),
+    #[error(transparent)]
+    Validation(#[from] ValidationError),
+    #[error(transparent)]
+    RMP(#[from] std::io::Error),
+}
+
+impl From<rmp::encode::ValueWriteError> for SerializeError {
+    fn from(err: rmp::encode::ValueWriteError) -> Self {
+        SerializeError::RMP(err.into())
+    }
+}
+
+impl From<TryFromIntError> for SerializeError {
+    fn from(_: TryFromIntError) -> Self {
+        SerializeError::InvalidInput(InvalidInputError("try from int error"))
+    }
+}


### PR DESCRIPTION
Added support for enum variant with named fields
Added support for #[skip] to skip a field for both deserialization and serialization
Added support for #[default="xyz"] to default a field on deserialization
Updated serialize() to return Result<(), SerializeError>
Added unit tests for the above newly supported cases